### PR TITLE
Fix missing casual maps

### DIFF
--- a/EventListeners/MessageReactionAdd/ApproveDenyVote.js
+++ b/EventListeners/MessageReactionAdd/ApproveDenyVote.js
@@ -21,7 +21,7 @@ module.exports.execute = async (reaction, user) => {
                 reaction._emoji.name !== '🔄' &&
                 (reaction.count < mtcMajority || reaction.count == 1)
             ){
-                // It is too early to worry about taking any action. 
+                // It is too early to worry about taking any action.
                 return;
             }
             if (reaction.partial){
@@ -32,9 +32,9 @@ module.exports.execute = async (reaction, user) => {
                     return;
                 }
             }
-            
+
             const description = reaction.message.embeds[0].data.description;
-            const descSplit = description.split('**');                
+            const descSplit = description.split('**');
             const channel = reaction.client.channels.cache.get(config.channels.mtc);
             const active = await channel.threads.fetchActive(true)
             let feedbackThreads = active.threads.filter(x=>x.name.includes(`${descSplit[3]} Feedback`));
@@ -64,7 +64,7 @@ module.exports.execute = async (reaction, user) => {
                     reaction.message.channel.send({content:`You know better than to vote on your own submission, <@${user.id}>.`,allowedMentions:{"users":[]}})
                 }
             }
-            
+
             let decision;
             let wired;
             const isWired = new Promise((resolve,reject)=>{
@@ -82,7 +82,7 @@ module.exports.execute = async (reaction, user) => {
                 }
                 wireFunc();
             })
-            
+
             async function getDecision(){
                 if (reaction._emoji.name === '🔄'){
                     decision = "Refresh"
@@ -91,10 +91,10 @@ module.exports.execute = async (reaction, user) => {
                 let yVotes = reaction.message.reactions.cache.get('✅');
                 let nVotes = reaction.message.reactions.cache.get('❌');
                 if ((reaction._emoji.name === '✅' || reaction._emoji.name === '❌')){
-                    if (yVotes.count >= config.mtcSettings.approveDenyThreshold || nVotes.count >= config.mtcSettings.approveDenyThreshold){     
+                    if (yVotes.count >= config.mtcSettings.approveDenyThreshold || nVotes.count >= config.mtcSettings.approveDenyThreshold){
                         if (feedbackArray.length < config.mtcSettings.feedbackThreshold){
                             decision = "Pending Feedback";
-                        } 
+                        }
                         else if (yVotes.count > nVotes.count){
                             if (!wired){
                                 decision = "Pending Manual Test"
@@ -105,7 +105,7 @@ module.exports.execute = async (reaction, user) => {
                         }
                         else if (nVotes.count > yVotes.count){
                             decision = "Denied"
-                        }                
+                        }
                         else {
                             // Tie
                             decision = "No Decision";
@@ -120,14 +120,14 @@ module.exports.execute = async (reaction, user) => {
                     decision = "Stop Clicking Weird Shit"
                 }
             }
-    
+
             isWired.then(async ()=>{
                 await reaction.message.fetch();
 
                 await getDecision();
                 Respond();
             })
-    
+
             async function Respond(){
                 const rootUrl = GetFMRoot();
                 const mapByAuthorLinks = `[**${descSplit[1]}**](${rootUrl}map/${descSplit[3]}) by [**${descSplit[5]}**](${rootUrl}profile/${descSplit[5].replaceAll(" ","_")})`
@@ -165,10 +165,10 @@ module.exports.execute = async (reaction, user) => {
 
                     if (config.mtcSettings.useDiscussionChannel){
                         const discChannel = reaction.client.channels.cache.get(config.channels.mtcDiscussion);
-                        const discussionThread = discChannel.threads.cache.find(x=>x.name.includes(`${descSplit[3]} Discussion`))  
+                        const discussionThread = discChannel.threads.cache.find(x=>x.name.includes(`${descSplit[3]} Discussion`))
                         await discussionThread?.setArchived(true);
                     }
-                    
+
                     var appr = reaction.message.reactions.cache.get('✅');
                     var deny = reaction.message.reactions.cache.get('❌');
                     var wire = reaction.message.reactions.cache.get('🔬');
@@ -182,7 +182,7 @@ module.exports.execute = async (reaction, user) => {
                     await deny.users.fetch().then(function(users){
                         denialList = Array.from(users.keys());
                         denialString = "No votes: ";
-                        denialList.forEach(x=> {if (x != config.users.bot){denialString += "<@" + x + "> "}});                
+                        denialList.forEach(x=> {if (x != config.users.bot){denialString += "<@" + x + "> "}});
                     })
                     await wire.users.fetch().then(function(users){
                         wireList = Array.from(users.keys());
@@ -195,13 +195,13 @@ module.exports.execute = async (reaction, user) => {
                         .setDescription(`${mapByAuthorLinks}\n\nID: **${descSplit[3]}**\n\n${approvalString}\n${denialString}${decision == "Denied" ? '' : '\n' + wireString}`)
                         .setThumbnail(`${rootUrl}preview/${descSplit[3]}.jpeg`).setTimestamp()
                     reaction.message.reactions.removeAll();
-        
+
                     reaction.message.channel.send({embeds:[embed],content:`**${decision.toLocaleUpperCase()} FOR ROTATION** \n${mapByAuthor}`,allowedMentions: {"users":[]}})
                         .then(async (sent)=>{
                             if (decision === "Approved"){
                                 var mtcAdminChannel = reaction.client.channels.cache.get(config.channels.mtcAdmin);
                                 var mtcAnnouncementChannel = reaction.client.channels.cache.get(config.channels.mtcAnnouncements);
-                                
+
                                 const headers = {
                                     'x-mtc-api-key': process.env.ENVIRONMENT == "Production" ? process.env.PROD_API_KEY : process.env.STAGING_API_KEY
                                 }
@@ -230,7 +230,7 @@ module.exports.execute = async (reaction, user) => {
                                         console.error(err);
                                     }
                                 })
-                            }                                
+                            }
                         }).then(()=>{
                             reaction.message.suppressEmbeds(true);
                         }).then(()=>{
@@ -252,7 +252,7 @@ module.exports.execute = async (reaction, user) => {
                                 embeds:[embed]
                             })
                         })
-                    
+
                 }
             }
         }

--- a/EventListeners/MessageReactionAdd/PromotionVote.js
+++ b/EventListeners/MessageReactionAdd/PromotionVote.js
@@ -132,7 +132,7 @@ module.exports.execute = async (reaction, user) => {
                                 const headers = {
                                     'x-mtc-api-key': process.env.ENVIRONMENT == "Production" ? process.env.PROD_API_KEY : process.env.STAGING_API_KEY
                                 }
-                                const url = `${config.urls.api}/updatemap/${mapId}?category=rotation&weight=1`
+                                const url = `${config.urls.api}/updatemap/${mapId}?category=rotation&weight=1&ratingType=inCasualRotation`
                                 // const url = `${config.urls.api}/updatemap/${mapId}?category=${playlist.toLowerCase()}&weight=${weight}`
                                 axios({method:'post',url:url,headers:headers}).then(function(resp){
                                     var mtcAdminChannel = reaction.client.channels.cache.get(config.channels.mtcAdmin);

--- a/EventListeners/MessageReactionAdd/PromotionVote.js
+++ b/EventListeners/MessageReactionAdd/PromotionVote.js
@@ -21,7 +21,7 @@ module.exports.execute = async (reaction, user) => {
                 reaction._emoji.name !== '🔄' &&
                 (reaction.count < mtcMajority || reaction.count == 1)
             ){
-                // It is too early to worry about taking any action. 
+                // It is too early to worry about taking any action.
                 return;
             }
             if (reaction.partial){
@@ -40,8 +40,8 @@ module.exports.execute = async (reaction, user) => {
                 }
                 let yVotes = reaction.message.reactions.cache.get('✅');
                 let nVotes = reaction.message.reactions.cache.get('⏳');
-                if ((reaction._emoji.name === '✅' || reaction._emoji.name === '⏳')){                
-                    if (yVotes.count >= config.mtcSettings.approveDenyThreshold || nVotes.count >= config.mtcSettings.approveDenyThreshold){ 
+                if ((reaction._emoji.name === '✅' || reaction._emoji.name === '⏳')){
+                    if (yVotes.count >= config.mtcSettings.approveDenyThreshold || nVotes.count >= config.mtcSettings.approveDenyThreshold){
                         if (yVotes.count > nVotes.count){
                             decision = "Added";
                         }
@@ -61,16 +61,16 @@ module.exports.execute = async (reaction, user) => {
                 else {
                     decision = "Stop Clicking Weird Shit"
                 }
-                
+
             }
 
-            async function Respond(){                    
+            async function Respond(){
                 const iconUrl = 'https://cdn.discordapp.com/icons/368194770553667584/9bbd5590bfdaebdeb34af78e9261f0fe.webp?size=96'
                 const mapByAuthor = reaction.message.embeds[0].data.description.split("Current Score:")[0];
                 const score = reaction.message.embeds[0].data.description.split(mapByAuthor)[1].split("Map ID:")[0];
                 const mapId = reaction.message.embeds[0].data.description.split("Map ID: ")[1];
                 const RaR = `Current Rating: ${score.split("Current Score:")[1]}`
-                
+
                 if (decision === "Refresh"){
                     await reaction.users.remove(user.id);
                     return;
@@ -87,15 +87,15 @@ module.exports.execute = async (reaction, user) => {
                         throw new Exception();
                     }
                     reaction.message.unpin();
-                    
+
                     // if (config.mtcSettings.useDiscussionChannel){
                     //     const last = mapByAuthor.lastIndexOf(" by ");
                     //     const mapName = mapByAuthor.slice(2,last);
                     //     const channel = reaction.client.channels.cache.get(config.channels.mtcDiscussion);
-                    //     const thread = channel.threads.cache.find(x=>x.name === `${mapName} Promotion Discussion`)  
-                    //     await thread.setArchived(true);              
+                    //     const thread = channel.threads.cache.find(x=>x.name === `${mapName} Promotion Discussion`)
+                    //     await thread.setArchived(true);
                     // }
-                    
+
                     const last = mapByAuthor.lastIndexOf(" by ");
                     const mapName = mapByAuthor.slice(2,last);
                     const channel = reaction.client.channels.cache.get(config.channels.mtc)
@@ -116,7 +116,7 @@ module.exports.execute = async (reaction, user) => {
                     await delay.users.fetch().then(function(users){
                         delayList = Array.from(users.keys());
                         delayString = "Delay votes: ";
-                        delayList.forEach(x=> {if (x != config.users.bot){delayString += "<@" + x + "> "}});                
+                        delayList.forEach(x=> {if (x != config.users.bot){delayString += "<@" + x + "> "}});
                     })
                     const imageUrl = `${reaction.message.embeds[0].data.image.url}`
                     const embed = new EmbedBuilder().setColor(decision === 'Added' ? '#7bcf5c' : '#ffca3a')
@@ -125,7 +125,7 @@ module.exports.execute = async (reaction, user) => {
                         .setThumbnail(imageUrl).setTimestamp()
 
                     reaction.message.reactions.removeAll();
-        
+
                     reaction.message.channel.send({embeds:[embed],content:`${header}\n${mapByAuthor}`,allowedMentions: {"users":[]}})
                         .then(sent=>{
                             if (decision == "Added"){
@@ -160,7 +160,7 @@ module.exports.execute = async (reaction, user) => {
                         }).then(()=>{
                             reaction.message.suppressEmbeds(true);
                         })
-                    
+
                 }
             }
 

--- a/EventListeners/MessageReactionAdd/RemoveKeepVote.js
+++ b/EventListeners/MessageReactionAdd/RemoveKeepVote.js
@@ -6,21 +6,21 @@ module.exports.execute = async (reaction, user) => {
     if(reaction.message.channelId === config.channels.mtc){
         // Use this IF block to determine if it is a reaction on a map removal nomination
         if (reaction.message.content.includes("map removal nomination")){
-            
+
             const currentDate = new Date();
             const guild =  await reaction.client.guilds.fetch(config.guildId);
             const mtcRole = guild.roles.cache.get(config.roles.mtc);
             const mtcMajority = Math.ceil(mtcRole.members.size/2) + 1
-            
+
             //Make sure we're counting all reactions even if the bot restarts
             reaction.message.fetch();
 
             if (
-                (((currentDate - reaction.message.createdTimestamp)/3600000).toFixed(2) < config.mtcSettings.minimumVoteTime || config.mtcSettings.minimumVoteTime == 0) && 
+                (((currentDate - reaction.message.createdTimestamp)/3600000).toFixed(2) < config.mtcSettings.minimumVoteTime || config.mtcSettings.minimumVoteTime == 0) &&
                 reaction._emoji.name !== '🔄' &&
                 (reaction.count < mtcMajority || reaction.count == 1)
             ){
-                // It is too early to worry about taking any action. 
+                // It is too early to worry about taking any action.
                 return;
             }
             if (reaction.partial){
@@ -39,8 +39,8 @@ module.exports.execute = async (reaction, user) => {
                 }
                 let yVotes = reaction.message.reactions.cache.get('✅');
                 let nVotes = reaction.message.reactions.cache.get('❌');
-                if ((reaction._emoji.name === '✅' || reaction._emoji.name === '❌')){                
-                    if (yVotes.count >= config.mtcSettings.approveDenyThreshold || nVotes.count >= config.mtcSettings.approveDenyThreshold){ 
+                if ((reaction._emoji.name === '✅' || reaction._emoji.name === '❌')){
+                    if (yVotes.count >= config.mtcSettings.approveDenyThreshold || nVotes.count >= config.mtcSettings.approveDenyThreshold){
                         if (yVotes.count > nVotes.count){
                             decision = "Removed";
                         }
@@ -84,7 +84,7 @@ module.exports.execute = async (reaction, user) => {
                         header = `MAP KEPT`
                     }
                     reaction.message.unpin();
-                    
+
                     const last = mapByAuthor.lastIndexOf(" by ");
                     const mapName = mapByAuthor.slice(2,last);
                     const channel = reaction.client.channels.cache.get(config.channels.mtc)
@@ -102,7 +102,7 @@ module.exports.execute = async (reaction, user) => {
                     //         await thread.setArchived(true);
                     //     }
                     // }
-                    
+
                     var appr = reaction.message.reactions.cache.get('✅');
                     var deny = reaction.message.reactions.cache.get('❌');
                     var approvalList = []; var denialList = [];
@@ -115,7 +115,7 @@ module.exports.execute = async (reaction, user) => {
                     await deny.users.fetch().then(function(users){
                         denialList = Array.from(users.keys());
                         denialString = "No votes: ";
-                        denialList.forEach(x=> {if (x != config.users.bot){denialString += "<@" + x + "> "}});                
+                        denialList.forEach(x=> {if (x != config.users.bot){denialString += "<@" + x + "> "}});
                     })
                     const imageUrl = `${reaction.message.embeds[0].data.image.url}`
                     const embed = new EmbedBuilder().setColor(decision === 'Kept' ? '#7bcf5c' : '#da3e52')
@@ -124,7 +124,7 @@ module.exports.execute = async (reaction, user) => {
                         .setThumbnail(imageUrl).setTimestamp()
 
                     reaction.message.reactions.removeAll();
-        
+
                     reaction.message.channel.send({embeds:[embed],content:`${header}\n${mapByAuthor}`,allowedMentions: {"users":[]}})
                         .then(sent=>{
                             if (decision === "Removed"){
@@ -160,7 +160,7 @@ module.exports.execute = async (reaction, user) => {
                         }).then(()=>{
                             reaction.message.suppressEmbeds(true);
                         })
-                    
+
                 }
             }
 

--- a/Functions/CalculateRotationBalance.js
+++ b/Functions/CalculateRotationBalance.js
@@ -11,7 +11,7 @@ module.exports = (client, interaction) => {
                 'x-mtc-api-key': process.env.ENVIRONMENT == "Production" ? process.env.PROD_API_KEY : process.env.STAGING_API_KEY
             }
             const maps = await nfetch(`${config.urls.tagpro}/allmaps.json`, {headers:headers})
-            const body = await maps.json();            
+            const body = await maps.json();
             resolve(body);
         }
         getMaps();
@@ -132,7 +132,7 @@ module.exports = (client, interaction) => {
             .setColor("#186360")
             .setAuthor({name:"State of Rotation",iconURL:"https://imgur.com/QWrriCS.png"})
             .setTimestamp()
-        
+
         const rotSize = mapData[0].totalWeight;
         for (var i = 0; i < mapData.length; i++){
             var formattedCategory = mapData[i].category.charAt(0).toUpperCase() + mapData[i].category.slice(1)
@@ -167,7 +167,7 @@ module.exports = (client, interaction) => {
                     )
                 }
                 if (mapData[i].category == "rotation"){
-                    embed.addFields(                        
+                    embed.addFields(
                         {
                             name: "\n\u200b",
                             value: "\u200b",
@@ -220,7 +220,7 @@ module.exports = (client, interaction) => {
             else {
                 item.totalWeight = "\`\`\`\n🟡 "+item.totalWeight.toFixed(2)+ "\n🟡 Expect " + ideal.size[1] + "-" + ideal.size[2] + "\`\`\`"
             }
-            
+
             if (item.CTFWeight/rotSize*100 < ideal.ctfBal[0] || item.CTFWeight/rotSize*100 > ideal.ctfBal[3]){
                 item.CTFNFBalance = "\`\`\`\n🔴 CTF: " + (item.CTFWeight/rotSize*100).toFixed(2) + "%\n🔴 NF : " + (item.NFWeight/rotSize*100).toFixed(2) + "%\`\`\`"
             }
@@ -240,7 +240,7 @@ module.exports = (client, interaction) => {
             }
             else {
                 item.totalWeight = "\`\`\`\n🟢 Weight："+(item.totalWeight/rotSize*100).toFixed(2)+"%\`\`\`"
-            }                
+            }
         }
         if (item.category === "classic"){
             if (item.totalWeight/rotSize*100 > ideal.claBal[1]){
@@ -251,7 +251,7 @@ module.exports = (client, interaction) => {
             }
             else {
                 item.totalWeight = "\`\`\`\n🟢 Weight："+(item.totalWeight/rotSize*100).toFixed(2)+"%\`\`\`"
-            } 
+            }
         }
         if (item.category === "retired"){
             if (item.totalWeight/rotSize*100 > ideal.tbkBal[1]){
@@ -262,7 +262,7 @@ module.exports = (client, interaction) => {
             }
             else {
                 item.totalWeight = "\`\`\`\n🟢 Weight："+(item.totalWeight/rotSize*100).toFixed(2)+"%\`\`\`"
-            } 
+            }
         }
         if (item.category === "trial"){
             if (item.totalWeight/rotSize*100 > ideal.triBal[1]){
@@ -274,7 +274,7 @@ module.exports = (client, interaction) => {
             }
             else {
                 item.totalWeight = "\`\`\`\n🟢 Weight："+(item.totalWeight/rotSize*100).toFixed(2)+"%\`\`\`"
-            } 
+            }
         }
         if (item.category === "all"){
             if (item.avgScore > ideal.score[1]){
@@ -299,7 +299,7 @@ module.exports = (client, interaction) => {
             }
         }
     }
-    
+
     function getType(png){
         if (png == null){
             return "Placeholder"
@@ -311,7 +311,7 @@ module.exports = (client, interaction) => {
                 var canvas = Canvas.createCanvas();
                 canvas.width = image.width;
                 canvas.height = image.height;
-    
+
                 var context = canvas.getContext('2d');
                 context.drawImage(image,0,0);
                 var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
@@ -332,7 +332,7 @@ module.exports = (client, interaction) => {
                 switch(true){
                     case (blue==1 && red ==1 && yellow == 0): mapType = "CTF";
                         break;
-                    case (blue==0 && red ==0 && yellow == 1): mapType = "NF"; 
+                    case (blue==0 && red ==0 && yellow == 1): mapType = "NF";
                         break;
                 }
             }

--- a/Functions/CheckForExcessBlack.js
+++ b/Functions/CheckForExcessBlack.js
@@ -22,15 +22,15 @@ module.exports = async (mapId) => {
                 var canvas = Canvas.createCanvas();
                 canvas.width = image.width;
                 canvas.height = image.height;
-    
+
                 var context = canvas.getContext('2d');
                 context.drawImage(image,0,0);
                 var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-                
+
                 for (var i = 0; i < canvas.width * 4; i += 4){
                     var rgbString = `r${imageData.data[i]}g${imageData.data[i+1]}b${imageData.data[i+2]}`
                     if (rgbString != 'r0g0b0' && rgbString != 'r212g212b212'){
-                        topRowGood = true;                    
+                        topRowGood = true;
                     }
                 }
 
@@ -40,21 +40,21 @@ module.exports = async (mapId) => {
                         leftSideGood = true;
                     }
                 }
-    
+
                 for (var i = (canvas.width - 1) * 4; i < canvas.height * canvas.width * 4; i += canvas.width * 4){
                     var rgbString = `r${imageData.data[i]}g${imageData.data[i+1]}b${imageData.data[i+2]}`
                     if (rgbString != 'r0g0b0' && rgbString != 'r212g212b212'){
                         rightSideGood = true;
                     }
                 }
-    
+
                 for (var i = (canvas.height - 1) * canvas.width * 4; i < canvas.height * canvas.width * 4; i += 4) {
                     var rgbString = `r${imageData.data[i]}g${imageData.data[i+1]}b${imageData.data[i+2]}`
                     if (rgbString != 'r0g0b0' && rgbString != 'r212g212b212'){
                         bottomRowGood = true;
                     }
                 }
-    
+
                 if (topRowGood && rightSideGood && bottomRowGood && leftSideGood){
                     validSubmission = true;
                 } else {

--- a/Functions/FinalizeVotes.js
+++ b/Functions/FinalizeVotes.js
@@ -5,7 +5,7 @@ module.exports = async (client) => {
     let job = new cron.CronJob(config.mtcSettings.finalizeDateTime, checkForCompletedVotes)
     job.start();
 
-    async function checkForCompletedVotes(){ 
+    async function checkForCompletedVotes(){
         const guild =  await client.guilds.fetch(config.guildId);
         const channel = await guild.channels.cache.get(config.channels.mtc);
         const pins = await channel.messages.fetchPinned(true);
@@ -22,7 +22,7 @@ module.exports = async (client) => {
                     let c = Math.round(new Date(m.createdTimestamp).getTime() / 1000)
                     var now = Math.round(new Date().getTime() / 1000);
                     var mvtAgo = now - (config.mtcSettings.minimumVoteTime * 3600);
-    
+
                     // if the vote was called > X hours ago
                     // trust me this is what it means
                     if (c < mvtAgo){

--- a/Functions/GetAllMaps.js
+++ b/Functions/GetAllMaps.js
@@ -1,4 +1,4 @@
-const nfetch = (...args) => import('node-fetch').then(({default:fetch}) => fetch(...args)) 
+const nfetch = (...args) => import('node-fetch').then(({default:fetch}) => fetch(...args))
 const config = process.env.ENVIRONMENT == "Production" ? require("../config.json") : require("../localConfig.json")
 
 //Returns an array of all maps

--- a/Functions/GetFMRoot.js
+++ b/Functions/GetFMRoot.js
@@ -1,6 +1,6 @@
 const config = process.env.ENVIRONMENT == "Production" ? require("../config.json") : require("../localConfig.json")
 
-module.exports = () => {    
+module.exports = () => {
     if (new Date(config.system.FMHostSwitchDate) >= new Date()){
         return "https://fortunatemaps.herokuapp.com/"
     }

--- a/Functions/GetMapById.js
+++ b/Functions/GetMapById.js
@@ -1,4 +1,4 @@
-const nfetch = (...args) => import('node-fetch').then(({default:fetch}) => fetch(...args)) 
+const nfetch = (...args) => import('node-fetch').then(({default:fetch}) => fetch(...args))
 const config = process.env.ENVIRONMENT == "Production" ? require("../config.json") : require("../localConfig.json")
 
 module.exports = async (mapId) => {
@@ -25,5 +25,5 @@ module.exports = async (mapId) => {
                 return tmp;
             }
         }
-    }                    
+    }
 }

--- a/Functions/GetMapByName.js
+++ b/Functions/GetMapByName.js
@@ -1,4 +1,4 @@
-const nfetch = (...args) => import('node-fetch').then(({default:fetch}) => fetch(...args)) 
+const nfetch = (...args) => import('node-fetch').then(({default:fetch}) => fetch(...args))
 const config = process.env.ENVIRONMENT == "Production" ? require("../config.json") : require("../localConfig.json")
 
 module.exports = async (mapName, resultNumber = 1, isRemoval = false, isTrial = false) => {
@@ -46,5 +46,5 @@ module.exports = async (mapName, resultNumber = 1, isRemoval = false, isTrial = 
     catch (err){
         console.error(err);
     }
-    
+
 }

--- a/Functions/PingMTC.js
+++ b/Functions/PingMTC.js
@@ -43,7 +43,7 @@ module.exports = async (client) => {
                     });
                 })
             })
-    
+
             getLazyPeople.then(()=>{
                 const naughtyPeople = [];
                 mtcUsers.forEach(u=>{

--- a/Functions/RemoveButtonsFromOriginal.js
+++ b/Functions/RemoveButtonsFromOriginal.js
@@ -27,7 +27,7 @@ module.exports = async (interaction, removeEmbeds = false, newContentString = nu
             }
         }
         else {
-            newContent = {                    
+            newContent = {
                 components: []
             }
         }

--- a/Functions/ValidateSubmission.js
+++ b/Functions/ValidateSubmission.js
@@ -19,7 +19,7 @@ module.exports = async (client, interaction) => {
                     isValid = false;
                     await interaction.editReply({content:"You still have a submission under review. Please try again later.", ephemeral:true})
                     return isValid;
-                }            
+                }
             }
         })
     }

--- a/Functions/index.js
+++ b/Functions/index.js
@@ -12,15 +12,15 @@ const FinalizeVotes = require("./FinalizeVotes");
 const CheckForExistingMapInRotation = require("./CheckForExistingMapInRotation");
 const GetMapWithStats = require("./GetMapWithStats");
 
-module.exports = { 
+module.exports = {
     PingMTC,
     FinalizeVotes,
-    RemoveButtonsFromOriginal, 
-    ValidateSubmission, 
-    CalculateRotationBalance, 
-    GetMapById, 
-    GetMapByName, 
-    GetAllMaps, 
+    RemoveButtonsFromOriginal,
+    ValidateSubmission,
+    CalculateRotationBalance,
+    GetMapById,
+    GetMapByName,
+    GetAllMaps,
     CheckForExcessBlack,
     RefreshPins,
     GetFMRoot,

--- a/Interactions/Buttons/ConfirmManualAdd.js
+++ b/Interactions/Buttons/ConfirmManualAdd.js
@@ -23,7 +23,7 @@ module.exports.execute = async (interaction) => {
                 interaction.editReply({content:`${invalid}\n*Don't forget to rewire any gates, portals, bombs, and buttons after resizing.*`,ephemeral:true,components:[row]});
             } else {
                 const description = interaction.message.embeds[0].data.description;
-                const descSplit = description.split('**');                
+                const descSplit = description.split('**');
                 const channel = interaction.client.channels.cache.get(config.channels.mtc);
                 const mtcAdminChannel = interaction.client.channels.cache.get(config.channels.mtcAdmin);
                 const mtcAnnouncementChannel = interaction.client.channels.cache.get(config.channels.mtcAnnouncements);
@@ -66,10 +66,10 @@ module.exports.execute = async (interaction) => {
                 })
             }
         }
-        // This is needed to remove the components (buttons)            
+        // This is needed to remove the components (buttons)
         RemoveButtonsFromOriginal(interaction);
     }
     catch (err){
         console.error(err);
     }
-}     
+}

--- a/Interactions/Buttons/ConfirmMapPromotion.js
+++ b/Interactions/Buttons/ConfirmMapPromotion.js
@@ -23,7 +23,7 @@ module.exports.execute = async (interaction) => {
                 });
             }
             const imgUrl = `${config.urls.image}/${map.name.split(" ").join("_").replaceAll("_","%20").trim()}-small.png`
-            
+
             const embed = new EmbedBuilder()
             .setImage(imgUrl)
             .setColor("#6CD4FF")
@@ -32,7 +32,7 @@ module.exports.execute = async (interaction) => {
             // .setDescription("**"+interaction.message.components[0].components[0].data.options.filter(x=>x.value==interaction.values[0])[0].label+"**\n"
             //     + interaction.message.components[0].components[0].data.options.filter(x=>x.value==interaction.values[0])[0].description)
             .setFooter({text:`Please react ✅ to add or ⏳ to wait for now.`})
-            
+
             const msg = {
                 content:`**ATTENTION <@&${config.roles.mtc}>:** New map promotion nomination received from <@${interaction.user.id}>.`,
                 embeds:[embed],
@@ -41,7 +41,7 @@ module.exports.execute = async (interaction) => {
 
             interaction.reply({content:"Promotion vote posted in MTC channel!",ephemeral:true})
             mtcChannel.send(msg).then(sent => {sent.react("✅").then(()=>{sent.react("⏳")}).then(()=>sent.pin())
-                .then(() => { sent.startThread({name:`${map.name} Promotion Discussion`,autoArchiveDuration:4320,reason:"Private opportunity to discuss potential promotion"}); 
+                .then(() => { sent.startThread({name:`${map.name} Promotion Discussion`,autoArchiveDuration:4320,reason:"Private opportunity to discuss potential promotion"});
                     let sentMessageUrl = sent.url;
                     if (config.mtcSettings.useDiscussionChannel){
                         const discussionChannel = interaction.client.channels.cache.get(config.channels.mtcDiscussion);

--- a/Interactions/Buttons/ConfirmMapRemoval.js
+++ b/Interactions/Buttons/ConfirmMapRemoval.js
@@ -23,7 +23,7 @@ module.exports.execute = async (interaction) => {
                 });
             }
             const imgUrl = `${config.urls.image}/${map.name.split(" ").join("_").replaceAll("_","%20").trim()}-small.png`
-            
+
             const embed = new EmbedBuilder()
             .setImage(imgUrl)
             .setColor("#da3e52")
@@ -32,17 +32,17 @@ module.exports.execute = async (interaction) => {
             // .setDescription("**"+interaction.message.components[0].components[0].data.options.filter(x=>x.value==interaction.values[0])[0].label+"**\n"
             //     + interaction.message.components[0].components[0].data.options.filter(x=>x.value==interaction.values[0])[0].description)
             .setFooter({text:`Please react ✅ to remove or ❌ to keep.`})
-            
+
             const msg = {
                 content:`**ATTENTION <@&${config.roles.mtc}>:** New map removal nomination received from <@${interaction.user.id}>.`,
                 embeds:[embed],
                 allowedMentions:{"users":[],"roles":[]}
-            }            
-            
+            }
+
 
             interaction.reply({content:"Removal vote posted in MTC channel!",ephemeral:true})
             mtcChannel.send(msg).then(sent => {sent.react("✅").then(() => sent.react("❌")).then(() => sent.pin())
-            .then(() => {sent.startThread({name:`${map.name} Removal Discussion`,autoArchiveDuration:4320,reason:"Private opportunity to discuss removal"}); 
+            .then(() => {sent.startThread({name:`${map.name} Removal Discussion`,autoArchiveDuration:4320,reason:"Private opportunity to discuss removal"});
                             let sentMessageUrl = sent.url;
                             if (config.mtcSettings.useDiscussionChannel){
                                 const discussionChannel = interaction.client.channels.cache.get(config.channels.mtcDiscussion);
@@ -53,8 +53,7 @@ module.exports.execute = async (interaction) => {
                             }
                         })})
             RemoveButtonsFromOriginal(interaction);
-            
-            
+
         }
     }
     catch (err) {

--- a/Interactions/Buttons/ConfirmMapSubmission.js
+++ b/Interactions/Buttons/ConfirmMapSubmission.js
@@ -37,10 +37,10 @@ module.exports.execute = async (interaction) => {
                                     .setFooter({text:`Please react ✅ to approve or ❌ to reject.`})
                 let newContent = `**ATTENTION <@&${config.roles.mtc}>:** ${submissionType} [FM ID: \`${mapId}\`] received from <@${interaction.user.id}>.`
                 if (isUpdate) { newContent += `\nAdvancing this map will overwrite the PNG and JSON files of the existing map with this name in the game. It will not overwrite votes.` }
-                
+
                 mtcChannel.send({content:newContent,embeds:[newEmbed],allowedMentions:{users:[],roles:[]}}).then(sent => {
                     sent.react("✅").then(()=>sent.react("❌")).then(()=>sent.react("🔬")).then(()=>sent.pin())
-                    .then(()=>sent.startThread({name:`${mapName} ${mapId} Feedback - Visible to Mapmaker`,autoArchiveDuration:4320,reason:"Provide public feedback for the submission"}))                    
+                    .then(()=>sent.startThread({name:`${mapName} ${mapId} Feedback - Visible to Mapmaker`,autoArchiveDuration:4320,reason:"Provide public feedback for the submission"}))
                 })
                 if (config.mtcSettings.useDiscussionChannel){
                     const discussionChannel = interaction.client.channels.cache.get(config.channels.mtcDiscussion);
@@ -60,10 +60,10 @@ module.exports.execute = async (interaction) => {
                 }
             }
         }
-        // This is needed to remove the components (buttons)            
+        // This is needed to remove the components (buttons)
         RemoveButtonsFromOriginal(interaction);
     }
     catch (err){
         console.error(err);
     }
-}     
+}

--- a/Interactions/Buttons/ConfirmMapUpdate.js
+++ b/Interactions/Buttons/ConfirmMapUpdate.js
@@ -43,7 +43,7 @@ module.exports.execute = (interaction) => {
                     .setPlaceholder('Select Category/Weight, then click outside.')
                     .setMinValues(2)
                     .setMaxValues(2)
-                    .addOptions(catOptions)                    
+                    .addOptions(catOptions)
             )
         const row2 = new ActionRowBuilder()
             .addComponents(
@@ -58,10 +58,10 @@ module.exports.execute = (interaction) => {
                     .setLabel('Send it!')
                     .setCustomId('LiterallyDoesNothingLmao')
             )
-                    
+
         interaction.update({content:"Select exactly one playlist and one weight.",ephemeral:true,components:[row,row2]})
     }
     catch (err){
         console.error(err);
     }
-}     
+}

--- a/Interactions/Buttons/ConfirmMapUpdate.js
+++ b/Interactions/Buttons/ConfirmMapUpdate.js
@@ -11,7 +11,8 @@ module.exports.execute = (interaction) => {
         let catSplit = msg.embeds[0].data.description.split("Category: **");
         let category = catSplit[1].split("**")[0];
         const catOptions = [
-            {label:'Rotation',value:'Rotation---'+mapId},
+            {label:'Casual Rotation',value:'Rotation---'+mapId+'---inCasualRotation'},
+            {label:'Ranked Rotation',value:'Rotation---'+mapId+'---inRankedRotation'},
             {label:'1.0',value:'1.0'},
             {label:'Trial',value:'Trial---'+mapId},
             {label:'0.5',value:'0.5'},

--- a/Interactions/Buttons/Index.js
+++ b/Interactions/Buttons/Index.js
@@ -8,13 +8,13 @@ const ConfirmGetCurrentRating = require("./ConfirmGetCurrentRating");
 const ConfirmResetVotes = require("./ConfirmResetVotes.js");
 const ShareToChannel = require("./ShareToChannel");
 
-module.exports = { 
-    ConfirmMapSubmission, 
-    CancelMapSubmission, 
-    ConfirmMapUpdate, 
+module.exports = {
+    ConfirmMapSubmission,
+    CancelMapSubmission,
+    ConfirmMapUpdate,
     ConfirmMapRemoval,
     ConfirmManualAdd,
-    CancelAction, 
+    CancelAction,
     ConfirmGetCurrentRating,
     ConfirmResetVotes,
     ShareToChannel

--- a/Interactions/Buttons/ShareToChannel.js
+++ b/Interactions/Buttons/ShareToChannel.js
@@ -54,7 +54,7 @@ module.exports.execute = async (interaction) => {
                 allowedMentions: {"users":[]},
                 fetchReply: true
             });
-    
+
             reply.react('👍');
             reply.react('👎');
             interaction.update({content:"Map shared!"})

--- a/Interactions/SelectMenus/submitupdate.js
+++ b/Interactions/SelectMenus/submitupdate.js
@@ -12,13 +12,15 @@ module.exports.execute = (interaction) => {
         let playlist = "";
         let mapId = "";
         let weight = 0;
-        var validWeight = false;
-        var validId = false;
-        for (var i = 0; i < interaction.values.length; i++){
+        let validWeight = false;
+        let validId = false;
+        let ratingType;
+        for (let i = 0; i < interaction.values.length; i++){
             if (interaction.values[i].includes("---")){
                 valSplit = interaction.values[i].split("---")
                 playlist = valSplit[0];
-                mapId = valSplit[1]
+                mapId = valSplit[1];
+                ratingType = valSplit[2]; // Undefined for non casual/ranked
                 validId = true;
             }
             else if (typeof parseFloat(interaction.values[i]) == 'number'){
@@ -37,7 +39,7 @@ module.exports.execute = (interaction) => {
         const headers = {
             'x-mtc-api-key': process.env.ENVIRONMENT == "Production" ? process.env.PROD_API_KEY : process.env.STAGING_API_KEY
         }
-        const url = `${config.urls.api}/updatemap/${mapId}?category=${playlist.toLowerCase()}&weight=${weight}`
+        const url = `${config.urls.api}/updatemap/${mapId}?category=${playlist.toLowerCase()}&weight=${weight}${ratingType ? "&ratingType=" + ratingType : ""}`
         axios({method:'post',url:url,headers:headers}).then(function(resp){
             if (resp.data && resp.data.includes("Updated map")){
                 console.info("Successful request. Response: ", resp.data)

--- a/Interactions/SelectMenus/submitupdate.js
+++ b/Interactions/SelectMenus/submitupdate.js
@@ -3,7 +3,7 @@ const { EmbedBuilder } = require("discord.js")
 const config = process.env.ENVIRONMENT == "Production" ? require("../../config.json") : require("../../localConfig.json")
 const axios = require('axios');
 const { GetFMRoot } = require("../../Functions");
-const nfetch = (...args) => import('node-fetch').then(({default:fetch}) => fetch(...args)) 
+const nfetch = (...args) => import('node-fetch').then(({default:fetch}) => fetch(...args))
 
 module.exports.execute = (interaction) => {
     try {
@@ -63,9 +63,9 @@ module.exports.execute = (interaction) => {
                                 return tmp;
                             }
                         }
-                    }                    
+                    }
                 }
-        
+
                 searchMaps().then(function(x){
                     const imageUrl = `${config.urls.image}/${x.name.split(" ").join("_").replaceAll("_","%20").trim()}-small.png`
                     const baseUrl = GetFMRoot();

--- a/Interactions/SlashCommands/creativehelp.js
+++ b/Interactions/SlashCommands/creativehelp.js
@@ -95,8 +95,8 @@ module.exports.execute = (interaction) => {
                 description: "MTC Admins can use this method to manually add a map non-democratically. ICE only.",
                 roles: "mtcAdmin"
             }
-        ]    
-    
+        ]
+
         const isMTC = interaction.member.roles.cache.some(r=>r.id == config.roles.mtc)
         const isMTCAdmin = interaction.member.roles.cache.some(r=>r.id == config.roles.mtcAdmin)
 
@@ -123,5 +123,5 @@ module.exports.execute = (interaction) => {
     }
     catch (err) {
         console.error(err);
-    }    
+    }
 }

--- a/Interactions/SlashCommands/findfortunatemap.js
+++ b/Interactions/SlashCommands/findfortunatemap.js
@@ -49,7 +49,7 @@ module.exports.execute = (interaction) => {
             }, function(error, response, html){
                 if(!error && response.statusCode == 200){
                     const $ = cheerio.load(html);
-                    title = $('.card-title').find('b').first().text() 
+                    title = $('.card-title').find('b').first().text();
                     author = $('.card-title').find('b').last().text();
                 }
                 else {
@@ -60,7 +60,7 @@ module.exports.execute = (interaction) => {
                 }
                 else {
                     const formattedMapByAuthor = `${title.length > 125 ? title.substring(0,122)+ '...' : title} by ${author.length > 125 ? author.substring(0,122)+ '...' : author}`
-                    const formattedLinks = `**${code}** | [**Map**](${baseUrl}map/${code}) | [**Author**](${baseUrl}profile/${author.split(" ").join("_")}) | [**Test Map**](${baseUrl}test/${code})`                
+                    const formattedLinks = `**${code}** | [**Map**](${baseUrl}map/${code}) | [**Author**](${baseUrl}profile/${author.split(" ").join("_")}) | [**Test Map**](${baseUrl}test/${code})`
                     const embed = new EmbedBuilder()
                         .setColor('#7bcf5c')
                         .setImage(imageUrl)
@@ -99,9 +99,9 @@ module.exports.execute = (interaction) => {
                     }
                 })
             })
-    
+
             getHTML.then((x)=>{
-                var foundMatch = false;            
+                var foundMatch = false;
                 if (x.name != "" && x.author != ""){
                     foundMatch = true;
                 }
@@ -134,7 +134,7 @@ module.exports.execute = (interaction) => {
                 }
                 else {
                     row.addComponents(
-                        new ButtonBuilder().setCustomId(`findfortunatemap---${searchString}---${counterMinusOne}`).setStyle(ButtonStyle.Primary).setLabel('🡰 Prev Map'),                    
+                        new ButtonBuilder().setCustomId(`findfortunatemap---${searchString}---${counterMinusOne}`).setStyle(ButtonStyle.Primary).setLabel('🡰 Prev Map'),
                     )
                 }
                 row.addComponents(

--- a/Interactions/SlashCommands/findmap.js
+++ b/Interactions/SlashCommands/findmap.js
@@ -70,7 +70,7 @@ module.exports.execute = (interaction) => {
             }
             else {
                 row.addComponents(
-                    new ButtonBuilder().setCustomId(`findmap---${searchString}---${counterMinusOne}`).setStyle(ButtonStyle.Primary).setLabel('🡰 Prev Map'),                    
+                    new ButtonBuilder().setCustomId(`findmap---${searchString}---${counterMinusOne}`).setStyle(ButtonStyle.Primary).setLabel('🡰 Prev Map'),
                 )
             }
             row.addComponents(

--- a/Interactions/SlashCommands/getfeedback.js
+++ b/Interactions/SlashCommands/getfeedback.js
@@ -40,5 +40,5 @@ module.exports.execute = (interaction) => {
             feedbackArray[i].length > 0 ? response += "➢ " + feedbackArray[i] + "\n" : response += "";
         }
         interaction.reply({content:`${response}`,ephemeral:true})
-    })        
+    });
 }

--- a/Interactions/SlashCommands/index.js
+++ b/Interactions/SlashCommands/index.js
@@ -15,16 +15,16 @@ const MTC = require("./mtc");
 const ResetVotes = require("./resetvotes");
 const RankedMapInfo = require("./rankedmapinfo");
 
-module.exports = { 
-    SubmitMap, 
-    RemoveMap, 
-    GetFeedback, 
-    RotationSummary, 
+module.exports = {
+    SubmitMap,
+    RemoveMap,
+    GetFeedback,
+    RotationSummary,
     UpdateMap,
     ManualAdd,
-    FindMap, 
+    FindMap,
     FindFortunateMap,
-    GetCurrentRating, 
+    GetCurrentRating,
     CreativeHelp,
     PromoteMap,
     TrialSummary,

--- a/Interactions/SlashCommands/promotemap.js
+++ b/Interactions/SlashCommands/promotemap.js
@@ -28,7 +28,7 @@ module.exports.execute = (interaction) => {
         }
 
         async function searchMaps(){
-            var foundMatch = false;            
+            var foundMatch = false;
             const map = await GetMapByName(searchString, counter, false, true);
             if (map != null){
                 foundMatch = true;

--- a/Interactions/SlashCommands/submitmap.js
+++ b/Interactions/SlashCommands/submitmap.js
@@ -30,7 +30,7 @@ module.exports.execute = (interaction) => {
             axios.get(mapUrl).then(async function(resp, error){
                 if(!error && resp.status == 200){
                     const $ = cheerio.load(resp.data);
-                    title = $('.card-title').find('b').first().text() 
+                    title = $('.card-title').find('b').first().text();
                     author = $('.card-title').find('b').last().text();
                     description = $('.map-description').text();
                 }

--- a/bot.js
+++ b/bot.js
@@ -13,18 +13,18 @@ const FinalizeVotes = require("./Functions/FinalizeVotes");
 
 const client = new Client({
     intents: [
-        GatewayIntentBits.Guilds, 
-        GatewayIntentBits.DirectMessages, 
-        GatewayIntentBits.GuildMessages, 
-        GatewayIntentBits.GuildMessageReactions, 
-        GatewayIntentBits.MessageContent, 
-        GatewayIntentBits.GuildMembers 
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.DirectMessages,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.GuildMessageReactions,
+        GatewayIntentBits.MessageContent,
+        GatewayIntentBits.GuildMembers,
     ],
     partials: [
-        Partials.Channel, 
-        Partials.Message, 
-        Partials.Reaction, 
-        Partials.User 
+        Partials.Channel,
+        Partials.Message,
+        Partials.Reaction,
+        Partials.User,
     ]
 });
 //client.setMaxListeners(20)


### PR DESCRIPTION
Adds parameter for `inRankedRotation` and `inCasualRotation` so that maps are not missing from the /maps page after promotion

Adds the ability for maps to be added to or removed from the ranked rotation via the `/updatemap` command. Will require a documentation update or potentially just button labeling to specify that a map currently in both rotations can be removed from a single rotation by updating the map with the queue to remove from and a weight of 0. So to keep a map in casual but remove it from ranked, select Ranked rotation and weight=0.

Do not merge until coordinated with the next TPFG release as there is a tagpro-side change to handle this updated format and the buttons will not work as expected until then.