### PR TITLE
Fetch and filter reacting members, no creator ping

### DIFF
--- a/Functions/FinalizeVotes.js
+++ b/Functions/FinalizeVotes.js
@@ -8,7 +8,7 @@ module.exports = async (client) => {
     async function checkForCompletedVotes(){ 
         const guild =  await client.guilds.fetch(config.guildId);
         const channel = await guild.channels.cache.get(config.channels.mtc);
-        const pins = await channel.messages.fetchPinned(true);
+        const pins = await channel.messages.fetchPins(true);
         if (pins){
             console.log("Checking pins for completed votes...")
             pins.forEach(async p => {

--- a/Functions/RefreshPins.js
+++ b/Functions/RefreshPins.js
@@ -2,7 +2,7 @@ const config = process.env.ENVIRONMENT == "Production" ? require("../config.json
 module.exports = async (client) => {
     const guild =  await client.guilds.fetch(config.guildId);
     const channel = await guild.channels.fetch(config.channels.mtc);
-    const pins = await channel.messages.fetchPinned(true);
+    const pins = await channel.messages.fetchPins(true);
     await guild.members.fetch();
     const mtcUsers = guild.roles.cache.get(config.roles.mtc).members.map(m=>m.user.id)
     if (pins.size > 0){

--- a/Functions/ValidateSubmission.js
+++ b/Functions/ValidateSubmission.js
@@ -8,7 +8,7 @@ module.exports = async (client, interaction) => {
     const mapId = msgSplit2[0];
     const mtcChannel = client.channels.cache.get(config.channels.mtc);
     if (config.mtcSettings.awaitMTCAction) {
-        const pins = await mtcChannel.messages.fetchPinned(true);
+        const pins = await mtcChannel.messages.fetchPins(true);
         pins.sort(function(a,b){
             return b.createdAt-a.createdAt;
         })


### PR DESCRIPTION
This branch should stop pinging the full MTC any time there is a pinned message. It should also stop pinging an MTC member for not reacting to a message that they submitted.

I have no real way to test this so please review before merging and be ready to rollback/let me know if it fails. If you can test locally on a setup you built that would be fine too, I just don't have any experience setting these bots up